### PR TITLE
fix: Flutter and Dart SDK versions not loading (infinite loader on macOS)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,8 +19,8 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.2.0+3
 
 environment:
-  sdk: ^3.12.0
-  flutter: ">=3.44.0"
+  sdk: ^3.10.0
+  flutter: ">=3.22.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Expanded supported environments to include Dart 3.10.0 and Flutter 3.22.0 or later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->